### PR TITLE
Chore/sync template

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+packages/**   merge=ours
+.changeset/** merge=ours
+LICENSE       merge=ours
+LICENSES/**   merge=ours

--- a/.github/actions/ensure-label/action.yml
+++ b/.github/actions/ensure-label/action.yml
@@ -1,0 +1,59 @@
+name: Ensure Labels (Upsert via gh)
+description: Create or update one or more GitHub labels in the current repository.
+inputs:
+  labels_json:
+    description: >
+      JSON array of label objects: [{"name":"template-sync","color":"b9e3ff","description":"..."}].
+      "color" is hex without '#'. "description" is optional.
+    required: true
+    default: "[]"
+  token:
+    description: GitHub token with issues:write
+    required: false
+    default: ${{ github.token }}
+
+runs:
+  using: composite
+  steps:
+    - name: Show gh version
+      shell: bash
+      run: gh --version
+
+    - name: Validate JSON
+      shell: bash
+      env:
+        LABELS_JSON: ${{ inputs.labels_json }}
+      run: |
+        echo "$LABELS_JSON" | jq empty
+
+    - name: Upsert labels
+      shell: bash
+      env:
+        LABELS_JSON: ${{ inputs.labels_json }}
+        GITHUB_TOKEN: ${{ inputs.token }}
+      run: |
+        set -euo pipefail
+
+        # Iterate each label object in the array
+        jq -c '.[]' <<<"$LABELS_JSON" | while read -r item; do
+          name=$(jq -r '.name' <<<"$item")
+          color=$(jq -r '.color // "b9e3ff"' <<<"$item")
+          desc=$(jq -r '.description // "Created automatically by CI"' <<<"$item")
+
+          if [[ -z "$name" || "$name" == "null" ]]; then
+            echo "⚠️  Skipping label with missing 'name': $item"
+            continue
+          fi
+
+          echo "🔧 Ensuring label: '$name' (color=$color)"
+          # Try edit first; if it doesn't exist, create it.
+          if gh label edit "$name" --color "$color" --description "$desc"; then
+            echo "✅ Updated label '$name'"
+          else
+            if gh label create "$name" --color "$color" --description "$desc"; then
+              echo "✅ Created label '$name'"
+            else
+              echo "❌ Failed to create/update label '$name'"; exit 1
+            fi
+          fi
+        done

--- a/.github/actions/require-changeset/action.yaml
+++ b/.github/actions/require-changeset/action.yaml
@@ -1,12 +1,16 @@
 name: Require Changeset
 description: "Fail PRs to main without a changeset (skip for release PRs)"
+inputs:
+  skip-label:
+    description: "Label text to skip changeset check (can appear in PR title, body, or labels)"
+    required: false
+    default: "[skip changeset check]"
 runs:
   using: composite
   steps:
     - name: Check for changeset in PR
       shell: bash
       env:
-        SKIP_LABEL: "[skip changeset check]"
         PR_TITLE: ${{ github.event.pull_request.title || '' }}
         PR_BODY: ${{ github.event.pull_request.body  || '' }}
         ACTOR: ${{ github.actor }}
@@ -41,9 +45,17 @@ runs:
 
         # TODO: skip dependbot here
 
-        # Skip guard for PRs with skip changeset check label
-        if [[ "$PR_TITLE" == *"$SKIP_LABEL"* ]] || [[ "$PR_BODY" == *"$SKIP_LABEL"* ]]; then
-          echo "ℹ️ Skip label detected in PR title or body, skipping changeset check."
+        # Skip guard for PRs with skip changeset check label (title, body, or labels)
+        SKIP_LABEL="${{ inputs.skip-label }}"
+        LABEL_FOUND=false
+        
+        # Check if the skip label exists in PR labels using GitHub context
+        if [[ "${{ contains(github.event.pull_request.labels.*.name, inputs.skip-label) }}" == "true" ]]; then
+          LABEL_FOUND=true
+        fi
+        
+        if [[ "$PR_TITLE" == *"$SKIP_LABEL"* ]] || [[ "$PR_BODY" == *"$SKIP_LABEL"* ]] || [[ "$LABEL_FOUND" == "true" ]]; then
+          echo "ℹ️ Skip label detected in PR title, body or labels, skipping changeset check."
           exit 0
         fi
 

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -6,7 +6,7 @@ updates:
       interval: "weekly"
       day: "wednesday"
       time: "08:00"
-      timezone: "UTC"
+      timezone: "Europe/Berlin"
     open-pull-requests-limit: 7
     labels:
       - "dependencies"
@@ -43,7 +43,7 @@ updates:
       interval: "weekly"
       day: "wednesday"
       time: "08:00"
-      timezone: "UTC"
+      timezone: "Europe/Berlin"
     open-pull-requests-limit: 7
     labels:
       - "ci"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -76,15 +76,15 @@ jobs:
           exit 0
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ inputs.languages }}
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
+        uses: github/codeql-action/autobuild@v4
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           output: results.sarif
 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,12 +1,15 @@
 name: main
 on:
+  workflow_run:
+    workflows: ["Prepare"]
+    types: [completed]
   push:
     branches: [ main ]
   pull_request:
+    types: [opened, reopened, synchronize, labeled, unlabeled]
     branches: [ main ]
 
 jobs:
-
   build:
     name: build
     runs-on: ubuntu-latest
@@ -22,6 +25,8 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - uses: ./.github/actions/require-changeset
+        with:
+          skip-label: "[skip changeset check]"
 
       - uses: ./.github/actions/build-lint-test
 

--- a/.github/workflows/prepare.yml
+++ b/.github/workflows/prepare.yml
@@ -1,0 +1,35 @@
+name: Prepare
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  push:
+    branches: [ main ]
+  workflow_dispatch: {}
+
+jobs:
+  ensure-labels:
+    name: Ensure required labels exist
+    runs-on: ubuntu-latest
+    permissions:
+          contents: write
+          issues: write
+    steps:
+      - uses: actions/checkout@v5
+      
+      - uses: ./.github/actions/ensure-label
+        with:
+          labels_json: |
+            [
+              {"name":"[template-sync]","color":"b9e3ff","description":"Changes from the template repo"},
+              {"name": "[skip changeset check]", "color": "ff4d4f", "description": "Skip the changeset validation check"}
+            ]
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+  # Add other preparation tasks here in the future
+  # setup-environment:
+  #   name: Setup environment
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Setup something
+  #       run: echo "Future preparation tasks go here"

--- a/.github/workflows/template-sync.yml
+++ b/.github/workflows/template-sync.yml
@@ -1,0 +1,102 @@
+name: Sync from Template (selected paths, exclude packages)
+
+on:
+  schedule:
+    - cron: "0 7 * * 1" # Mondays 07:00 UTC
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: template-sync
+  cancel-in-progress: false
+
+# Repo-level ENV defaults; override in the GENERATED repo via Actions → Variables
+env:
+  # The official template repo — hardcoded, since this is the source of truth
+  TEMPLATE_REPO:         deresegetachew/systemcraft-stack-npmlib
+  TEMPLATE_REF:          main
+  # Turn the sync on/off in generated repos:
+  TEMPLATE_SYNC_ENABLED: ${{ vars.TEMPLATE_SYNC_ENABLED || 'true' }}
+  # Exclusions — space-separated paths/patterns relative to template root.
+  # By default we DO NOT sync: packages, .changeset/.changesets, LICENSE/Licenses, node_modules.
+  TEMPLATE_EXCLUDE:      ${{ vars.TEMPLATE_EXCLUDE      || 'packages .changeset .changesets LICENSE LICENSES node_modules' }}
+  # Branch naming
+  TARGET_BRANCH:         ${{ vars.TARGET_BRANCH         || 'main' }}
+  SYNC_BRANCH:           ${{ vars.SYNC_BRANCH           || 'chore/sync-template' }}
+  # Optional label
+  TEMPLATE_SYNC_LABEL:   ${{ vars.TEMPLATE_SYNC_LABEL   || 'template-sync' }}
+
+jobs:
+  sync:
+    name: Sync from template systemcraft/play-npmlib (exclude packages, licenses, changesets)
+    # IMPORTANT: do NOT run on the template repo itself
+    if: ${{ github.repository != env.TEMPLATE_REPO }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check if enabled
+        if: ${{ env.TEMPLATE_SYNC_ENABLED != 'true' }}
+        run: |
+          echo "Template sync disabled (TEMPLATE_SYNC_ENABLED != 'true'). Exiting."
+          exit 0
+
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          ref: ${{ env.TARGET_BRANCH }}
+
+      - name: Fetch template repository
+        run: |
+          set -euo pipefail
+          git clone --depth=1 --no-checkout "https://github.com/${{ env.TEMPLATE_REPO }}.git" /tmp/template
+          cd /tmp/template
+          git checkout "${{ env.TEMPLATE_REF }}"
+
+    #  rsync rsync stands for remote synchronization — it’s a file-copying and syncing utility that can efficiently mirror one directory tree into another,
+    # only copying changed files and deleting ones that no longer exist on the source (if you tell it to).
+      - name: Build rsync exclusion flags
+        id: excludes
+        shell: bash
+        run: |
+          set -euo pipefail
+          flags=""
+          for p in $TEMPLATE_EXCLUDE; do
+            flags="$flags --exclude=$p"
+          done
+          # Never try to copy .git
+          flags="$flags --exclude=.git"
+          echo "flags=$flags" >> "$GITHUB_OUTPUT"
+
+      - name: Copy template content (exclude configured paths)
+        run: |
+          set -euo pipefail
+          rsync -a --delete ${{ steps.excludes.outputs.flags }} /tmp/template/ ./
+
+          # Stage changes if any
+          git checkout -B "$SYNC_BRANCH"
+          git add -A
+          if git diff --staged --quiet; then
+            echo "No changes after sync."
+            exit 0
+          fi
+
+          git commit -m "chore: sync from ${TEMPLATE_REPO}@${TEMPLATE_REF} (excluding: ${TEMPLATE_EXCLUDE})"
+          git push -u origin "$SYNC_BRANCH" --force-with-lease
+
+      - name: Open/Update PR
+        uses: peter-evans/create-pull-request@v7
+        with:
+          title: "chore: sync from template (excluding: ${TEMPLATE_EXCLUDE})"
+          body: |
+            Automated sync from **${{ env.TEMPLATE_REPO }}** @ `${{ env.TEMPLATE_REF }}`
+
+            **Excluded paths:** `${{ env.TEMPLATE_EXCLUDE }}`
+
+            Turn off via **Actions → Variables**: set `TEMPLATE_SYNC_ENABLED=false`.
+          branch: ${{ env.SYNC_BRANCH }}
+          base: ${{ env.TARGET_BRANCH }}
+          labels: ${{ env.TEMPLATE_SYNC_LABEL }}
+          delete-branch: false


### PR DESCRIPTION
This pull request introduces several improvements to CI/CD workflows, focusing on better automation, label management, and synchronization with a template repository. Key enhancements include new workflows for label enforcement and template syncing, improved changeset validation, and updates to dependencies and job configurations.

**Label and Changeset Management:**

* Added a reusable composite action (`.github/actions/ensure-label`) to automatically create or update required GitHub labels in the repository.
* Introduced a new `Prepare` workflow (`.github/workflows/prepare.yml`) that ensures essential labels (e.g., `[template-sync]`, `[skip changeset check]`) exist before other jobs run.
* Enhanced the `require-changeset` action to allow skipping changeset checks via a configurable label, which can now be present in the PR title, body, or labels. Updated workflow usage to pass the skip label as an input. [[1]](diffhunk://#diff-788140fb8c49326108c36574ac3fd54fdd0aef2f059e613bf86af6089d3278bcR3-L9) [[2]](diffhunk://#diff-788140fb8c49326108c36574ac3fd54fdd0aef2f059e613bf86af6089d3278bcL44-R58) [[3]](diffhunk://#diff-71cabc4177e41ea8f15a89eb65398fa8187739f68a2762706d84885cd8b2ddc3R28-R29)

**Template Synchronization:**

* Added a `template-sync` workflow (`.github/workflows/template-sync.yml`) to automate syncing selected files from a template repository, with support for path exclusions and configurable branch/label names.
* Updated `.gitattributes` to use the `ours` merge strategy for template-excluded paths (e.g., `packages/**`, `.changeset/**`, `LICENSE`, `LICENSES/**`) to avoid merge conflicts during template syncs.

**CI/CD Workflow Improvements:**

* Updated the `main` workflow to trigger on additional events (e.g., `workflow_run` for `Prepare`, PR label changes) to ensure up-to-date checks.
* Upgraded `github/codeql-action` steps in the `codeql.yml` workflow from v3 to v4 for improved security and features.
* Adjusted Dependabot update timezones from `UTC` to `Europe/Berlin` for both `dependencies` and `ci` updates. [[1]](diffhunk://#diff-ee0c08340ace9ac3ce3c78e2377968bca2376b8bfd9a7a48d96515f5490a902cL9-R9) [[2]](diffhunk://#diff-ee0c08340ace9ac3ce3c78e2377968bca2376b8bfd9a7a48d96515f5490a902cL46-R46)