### PR TITLE
fix: update condition to prevent sync on the template repository

### DIFF
--- a/.github/workflows/template-sync.yml
+++ b/.github/workflows/template-sync.yml
@@ -33,7 +33,7 @@ jobs:
   sync:
     name: Sync from template systemcraft/play-npmlib (exclude packages, licenses, changesets)
     # IMPORTANT: do NOT run on the template repo itself
-    if: ${{ github.repository != env.TEMPLATE_REPO }}
+    if: ${{ github.repository != 'deresegetachew/systemcraft-stack-npmlib' }}
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
This pull request makes a minor change to the workflow condition in `.github/workflows/template-sync.yml`. The condition now explicitly checks that the repository is not `'deresegetachew/systemcraft-stack-npmlib'` before running the sync job, instead of using the `TEMPLATE_REPO` environment variable.