### PR TITLE
chore: update TEMPLATE_SYNC_LABEL to use a comma-separated string format

### DIFF
--- a/.github/workflows/template-sync.yml
+++ b/.github/workflows/template-sync.yml
@@ -26,8 +26,8 @@ env:
   # Branch naming
   TARGET_BRANCH:         ${{ vars.TARGET_BRANCH         || 'main' }}
   SYNC_BRANCH:           ${{ vars.SYNC_BRANCH           || 'chore/sync-template' }}
-  # Optional label
-  TEMPLATE_SYNC_LABEL:   ${{ vars.TEMPLATE_SYNC_LABEL   || ['template-sync', 'skip-changeset-check'] }}
+  # Optional label(s) — when set via repo Variables this can be a comma-separated string
+  TEMPLATE_SYNC_LABEL:   ${{ vars.TEMPLATE_SYNC_LABEL   || 'template-sync,skip-changeset-check' }}
 
 jobs:
   sync:


### PR DESCRIPTION
This pull request makes a minor update to the workflow configuration for template synchronization. The main change is to how the `TEMPLATE_SYNC_LABEL` environment variable is set, switching from an array to a comma-separated string to improve compatibility with repository variables.

- Workflow configuration update:
  * Changed the `TEMPLATE_SYNC_LABEL` in `.github/workflows/template-sync.yml` from an array to a comma-separated string, allowing repository variables to set multiple labels as a single string.